### PR TITLE
fix: client.py sync_lib password escaping

### DIFF
--- a/dsc/client.py
+++ b/dsc/client.py
@@ -107,7 +107,7 @@ class SeafileClient:
             "-s", self.url,
             "-d", lib_dir,
             "-u", self.user,
-            "-p", self.password,
+            "-p", '"' + self.password + '"',
         ]
         _lg.info(
             "Syncing library %s: %s", lib_name,


### PR DESCRIPTION
Please add some escaping in password env, I have password similar "xxxx&zzzz", and "&" broke syncing:

```
2023-10-16 12:50:04,655 Listing local libraries: seaf-cli list
2023-10-16 12:50:05,108 Syncing library btsync: seaf-cli sync -l 3XX2-XXX-2eXXea -s https://xxxxxxxx.xx -d /dsc/seafile/btsync -u xxx@xx.xx -p ********
-bash: line 1: zzzz: command not found
Traceback (most recent call last):
  File "/usr/bin/seaf-cli", line 1023, in <module>
    main()
  File "/usr/bin/seaf-cli", line 1019, in main
    args.func(args)
  File "/usr/bin/seaf-cli", line 675, in seaf_sync
    token = get_token(url, username, password, tfa, conf_dir)
```